### PR TITLE
Fix an error when file directory doesnt exist locally

### DIFF
--- a/src/Plugin/SyncResourceFileBase.php
+++ b/src/Plugin/SyncResourceFileBase.php
@@ -101,7 +101,16 @@ abstract class SyncResourceFileBase extends SyncResourceBase {
       $this->processItemAsNewFile($entity, $item);
     }
     else {
-      file_put_contents($entity->getFileUri(), $item['contents']);
+      $uri = $entity->getFileUri();
+
+      /** @var \Drupal\Core\File\FileSystemInterface $fs */
+      $fs = \Drupal::service('file_system');
+      $directory = $fs->dirname($uri);
+
+      // Ensure the directory exists and is writable.
+      $fs->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
+
+      file_put_contents($uri, $item['contents']);
       $this->processItemAsExistingFile($entity, $item);
     }
   }
@@ -149,7 +158,16 @@ abstract class SyncResourceFileBase extends SyncResourceBase {
    * Process an existing file entity.
    */
   protected function processItemAsExistingFile(FileInterface $entity, SyncDataItem $item) {
-    file_put_contents($entity->getFileUri(), $item['contents']);
+    $uri = $entity->getFileUri();
+
+    /** @var \Drupal\Core\File\FileSystemInterface $fs */
+    $fs = \Drupal::service('file_system');
+    $directory = $fs->dirname($uri);
+
+    // Ensure the directory exists and is writable.
+    $fs->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
+
+    file_put_contents($uri, $item['contents']);
     $this->renameFile($entity, $item);
   }
 

--- a/src/Plugin/SyncResourceFileBase.php
+++ b/src/Plugin/SyncResourceFileBase.php
@@ -158,16 +158,7 @@ abstract class SyncResourceFileBase extends SyncResourceBase {
    * Process an existing file entity.
    */
   protected function processItemAsExistingFile(FileInterface $entity, SyncDataItem $item) {
-    $uri = $entity->getFileUri();
-
-    /** @var \Drupal\Core\File\FileSystemInterface $fs */
-    $fs = \Drupal::service('file_system');
-    $directory = $fs->dirname($uri);
-
-    // Ensure the directory exists and is writable.
-    $fs->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
-
-    file_put_contents($uri, $item['contents']);
+    file_put_contents($entity->getFileUri(), $item['contents']);
     $this->renameFile($entity, $item);
   }
 


### PR DESCRIPTION
On my local machine, if I didn't have the directory already created in sites/default/files that the sync module was trying to look in, the sync failed. So I added a few lines of code to create the directory if it doesn't exist. Solved the issue for me!