### PR TITLE
Phpfpm worker load.

### DIFF
--- a/config/install/sync.settings.yml
+++ b/config/install/sync.settings.yml
@@ -1,2 +1,3 @@
 log_verbose: FALSE
 email_fail: NULL
+queue_cron_time: 30

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -42,6 +42,13 @@ class SettingsForm extends ConfigFormBase {
       '#title' => t('Verbose Logging'),
       '#default_value' => $config->get('log_verbose'),
     ];
+    $form['queue_cron_time'] = [
+      '#type' => 'number',
+      '#title' => t('Queue cron time (seconds)'),
+      '#description' => t('Maximum seconds each sync queue may run per cron invocation. Amount set is how long phpfpm workers are occupied. If phpfpm workers are exceeded for a server, requests will queue until a worker is free, causing site speed to decline/fail.'),
+      '#default_value' => $config->get('queue_cron_time'),
+      '#min' => 0,
+    ];
     return parent::buildForm($form, $form_state);
   }
 
@@ -54,6 +61,7 @@ class SettingsForm extends ConfigFormBase {
     $this->config('sync.settings')
       ->set('email_fail', $values['email_fail'])
       ->set('log_verbose', $values['log_verbose'])
+      ->set('queue_cron_time', (int) $values['queue_cron_time'])
       ->save();
   }
 

--- a/sync.module
+++ b/sync.module
@@ -135,12 +135,13 @@ function sync_form_alter(&$form, FormStateInterface $form_state, $form_id) {
  * Implements hook_queue_info_alter().
  */
 function sync_queue_info_alter(&$definitions) {
+  $cron_time = (int) \Drupal::config('sync.settings')->get('queue_cron_time') ?: 30;
   foreach (\Drupal::service('plugin.manager.sync_resource')->getDefinitions() as $key => $definition) {
     $definitions['sync_' . $key] = [
       'id' => 'sync_' . $key,
       'title' => $definition['label'],
       'cron' => [
-        'time' => 180,
+        'time' => $cron_time,
       ],
       'class' => 'Drupal\sync\Plugin\QueueWorker\Sync',
       'provider' => 'sync',


### PR DESCRIPTION
On long running queues, all phpfpm workers could become occupied, causing site ttfb delays/failures.

For instance:
Sync populates queue.
Cron runs, holds worker for 180s.
While cron running, pantheon healthcheck hits every 2 min, traffic(large potential variance).

This will vary on server build, smaller builds being more vulnerable.

Changed 180s value to configurable in existing settings, default 30s.