### PR TITLE
Optimize phpfpm worker consumption.

### DIFF
--- a/config/install/sync.settings.yml
+++ b/config/install/sync.settings.yml
@@ -1,3 +1,2 @@
 log_verbose: FALSE
 email_fail: NULL
-queue_cron_time: 30

--- a/src/EventSubscriber/SyncSubscriber.php
+++ b/src/EventSubscriber/SyncSubscriber.php
@@ -20,13 +20,23 @@ class SyncSubscriber implements EventSubscriberInterface {
   protected $cron;
 
   /**
-   * Constructs an art board share runner.
+   * The application root.
+   *
+   * @var string
+   */
+  protected $appRoot;
+
+  /**
+   * Constructs a new SyncSubscriber object.
    *
    * @param \Drupal\Core\CronInterface $cron
    *   The cron service.
+   * @param string $app_root
+   *   The application root path.
    */
-  public function __construct(CronInterface $cron) {
+  public function __construct(CronInterface $cron, string $app_root) {
     $this->cron = $cron;
+    $this->appRoot = $app_root;
   }
 
   /**
@@ -36,9 +46,29 @@ class SyncSubscriber implements EventSubscriberInterface {
    *   The Event to process.
    */
   public function onTerminate(TerminateEvent $event) {
-    if (substr($event->getRequest()->getPathInfo(), 0, 11) === '/sync-cron/') {
-      $this->cron->run();
+    if ($event->getRequest()->attributes->get('_route') !== 'sync.cron') {
+      return;
     }
+    // Run cron in a background CLI process so the FPM worker is released
+    // immediately rather than parked for the duration of queue draining.
+    // Falls back to inline cron if exec is disabled (e.g. via php.ini
+    // disable_functions) or the drush binary isn't where we expect it
+    // (non-standard composer layout).
+    if (function_exists('exec')) {
+      // drupal/recommended-project (vendor at project root) is the common
+      // modern layout. drupal/legacy-project (vendor inside docroot) is the
+      // older one.
+      foreach ([
+        $this->appRoot . '/../vendor/bin/drush',
+        $this->appRoot . '/vendor/bin/drush',
+      ] as $drush) {
+        if (is_executable($drush)) {
+          exec(escapeshellarg($drush) . ' cron > /dev/null 2>&1 &');
+          return;
+        }
+      }
+    }
+    $this->cron->run();
   }
 
   /**

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -42,13 +42,6 @@ class SettingsForm extends ConfigFormBase {
       '#title' => t('Verbose Logging'),
       '#default_value' => $config->get('log_verbose'),
     ];
-    $form['queue_cron_time'] = [
-      '#type' => 'number',
-      '#title' => t('Queue cron time (seconds)'),
-      '#description' => t('Maximum seconds each sync queue may run per cron invocation. Amount set is how long phpfpm workers are occupied. If phpfpm workers are exceeded for a server, requests will queue until a worker is free, causing site speed to decline/fail.'),
-      '#default_value' => $config->get('queue_cron_time') ?? 30,
-      '#min' => 1,
-    ];
     return parent::buildForm($form, $form_state);
   }
 
@@ -61,7 +54,6 @@ class SettingsForm extends ConfigFormBase {
     $this->config('sync.settings')
       ->set('email_fail', $values['email_fail'])
       ->set('log_verbose', $values['log_verbose'])
-      ->set('queue_cron_time', (int) $values['queue_cron_time'])
       ->save();
   }
 

--- a/src/Plugin/QueueWorker/Sync.php
+++ b/src/Plugin/QueueWorker/Sync.php
@@ -14,7 +14,8 @@ use Drupal\sync\SyncJobQueueReleaseException;
  *
  * @QueueWorker(
  *   id = "sync",
- *   title = @Translation("Sync")
+ *   title = @Translation("Sync"),
+ *   cron = {"time" = 30}
  * )
  */
 class Sync extends QueueWorkerBase implements ContainerFactoryPluginInterface {

--- a/sync.install
+++ b/sync.install
@@ -125,3 +125,12 @@ function sync_update_8003() {
     $config->set('queue_cron_time', 30)->save();
   }
 }
+
+/**
+ * Remove the queue_cron_time setting now that the value is hardcoded.
+ */
+function sync_update_8004() {
+  \Drupal::configFactory()->getEditable('sync.settings')
+    ->clear('queue_cron_time')
+    ->save();
+}

--- a/sync.module
+++ b/sync.module
@@ -135,13 +135,16 @@ function sync_form_alter(&$form, FormStateInterface $form_state, $form_id) {
  * Implements hook_queue_info_alter().
  */
 function sync_queue_info_alter(&$definitions) {
-  $cron_time = (int) \Drupal::config('sync.settings')->get('queue_cron_time') ?: 30;
   foreach (\Drupal::service('plugin.manager.sync_resource')->getDefinitions() as $key => $definition) {
     $definitions['sync_' . $key] = [
       'id' => 'sync_' . $key,
       'title' => $definition['label'],
       'cron' => [
-        'time' => $cron_time,
+        // Bounds the per-queue processing budget so the inline-cron fallback
+        // in SyncSubscriber (used when exec() is disabled or drush isn't
+        // available) can't park an FPM worker for too long. The primary
+        // exec-background path runs in CLI and isn't affected by this value.
+        'time' => 30,
       ],
       'class' => 'Drupal\sync\Plugin\QueueWorker\Sync',
       'provider' => 'sync',

--- a/sync.services.yml
+++ b/sync.services.yml
@@ -27,6 +27,6 @@ services:
     arguments: ['@datetime.time']
   sync.subscriber:
     class: Drupal\sync\EventSubscriber\SyncSubscriber
-    arguments: ['@cron']
+    arguments: ['@cron', '%app.root%']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
Sets default runtime from 180 to 30. Intended for short running sync efficiency. Long running syncs should be managed with their own cli trigger so that they do not take forever to process.

Cron ran with exec, to no longer consume phpfpm workers.

Falls back to cron->run() if not a sync.cron route.

Uninstaller added to remove no longer used time configuration setting.