### PR TITLE
Optimize phpfpm worker consumption.

### DIFF
--- a/src/EventSubscriber/SyncSubscriber.php
+++ b/src/EventSubscriber/SyncSubscriber.php
@@ -63,7 +63,13 @@ class SyncSubscriber implements EventSubscriberInterface {
         $this->appRoot . '/vendor/bin/drush',
       ] as $drush) {
         if (is_executable($drush)) {
-          exec(escapeshellarg($drush) . ' cron > /dev/null 2>&1 &');
+          // setsid puts the child in its own session/process group so it
+          // survives the FPM worker exiting. Without it, hosts like Pantheon
+          // tear down the child when the parent worker is recycled. Guarded
+          // because setsid (from util-linux) isn't guaranteed on every host.
+          // Redirecting stdin from /dev/null ensures PHP doesn't wait on it.
+          $prefix = is_executable('/usr/bin/setsid') ? '/usr/bin/setsid ' : '';
+          exec($prefix . escapeshellarg($drush) . ' cron > /dev/null 2>&1 < /dev/null &');
           return;
         }
       }


### PR DESCRIPTION
Run exec command with setsid so the spawned drush cron survives FPM worker recycling on hosts that tear down child processes when the parent exits.

Guarded with is_executable(), since setsid (from util-linux) is virtually universal- but not 100% guaranteed.